### PR TITLE
fix(SingletonBehaviour): CRTP 制約追加と型キャスト検証の強化

### DIFF
--- a/Foundation/SingletonBehaviour.cs
+++ b/Foundation/SingletonBehaviour.cs
@@ -14,7 +14,7 @@ namespace Foundation
     /// Lookup uses <see cref="Object.FindAnyObjectByType{T}()"/> and therefore does not return assets,
     /// inactive objects, or objects with <see cref="HideFlags.DontSave"/> set.
     /// </remarks>
-    public abstract class SingletonBehaviour<T> : MonoBehaviour where T : MonoBehaviour
+    public abstract class SingletonBehaviour<T> : MonoBehaviour where T : SingletonBehaviour<T>
     {
         /// <summary>
         /// Cached singleton instance for this closed generic type (one per T).
@@ -106,6 +106,17 @@ namespace Foundation
             }
 
             _instance = this as T;
+
+            if (_instance == null)
+            {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+                Debug.LogError(
+                    message: $"[{GetType().Name}] must inherit SingletonBehaviour<{GetType().Name}>, not SingletonBehaviour<{typeof(T).Name}>."
+                );
+#endif
+                Destroy(this.gameObject);
+                return;
+            }
 
             if (this.transform.parent != null)
             {


### PR DESCRIPTION
### 概要

`SingletonBehaviour<T>` の型安全性を強化し、誤った継承パターンをコンパイル時および実行時に検出できるようにします。

### 背景

従来の実装では、以下のような誤用がコンパイルを通過し、実行時に `_instance` が `null` のまま動作する問題がありました：
```csharp
// 誤った実装例
public class A : SingletonBehaviour<B> { }
```

### 変更内容

#### 1. CRTP 制約の追加
```csharp
// Before
where T : MonoBehaviour

// After
where T : SingletonBehaviour<T>
```

これにより、型の不一致がコンパイルエラー（CS0311）として検出されます。

#### 2. ランタイム検証の追加
```csharp
_instance = this as T;

if (_instance == null)
{
    Debug.LogError(...);
    Destroy(this.gameObject);
    return;
}
```

中間基底クラスを使用した複雑な継承構造への防御として、実行時チェックも維持します。

### 影響範囲

| 対象 | 影響 |
|------|------|
| 正しい実装（`Foo : SingletonBehaviour<Foo>`） | なし |
| 誤った実装（`A : SingletonBehaviour<B>`） | コンパイルエラー |

### テスト

- [x] 正常系：`class Foo : SingletonBehaviour<Foo>` が従来通り動作
- [x] 異常系：`class A : SingletonBehaviour<B>` でコンパイルエラー発生を確認
- [x] Enter Play Mode Options 4パターンで破綻なし確認
  - Domain Reload: ON / Scene Reload: ON
  - Domain Reload: ON / Scene Reload: OFF
  - Domain Reload: OFF / Scene Reload: ON
  - Domain Reload: OFF / Scene Reload: OFF

### 関連ドキュメント

- [RuntimeInitializeLoadType.SubsystemRegistration](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/RuntimeInitializeLoadType.SubsystemRegistration.html)
- [Application.quitting](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Application-quitting.html)
- [Object.FindAnyObjectByType](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Object.FindAnyObjectByType.html)