### PR TITLE
fix(SingletonRuntime): PlaySessionId のオーバーフロー防止

### DIFF
--- a/Foundation/Singletons/SingletonRuntime.cs
+++ b/Foundation/Singletons/SingletonRuntime.cs
@@ -31,7 +31,8 @@ namespace Foundation.Singletons
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Initialize()
         {
-            PlaySessionId++;
+            if (PlaySessionId < int.MaxValue) PlaySessionId++;
+
             IsQuitting = false;
 
             Application.quitting -= OnQuitting;


### PR DESCRIPTION
### 概要

`PlaySessionId` が `int.MaxValue` に到達した際、オーバーフローして負値になるのを防止します。

### 変更内容
```csharp
// Before
PlaySessionId++;

// After
if (PlaySessionId < int.MaxValue) PlaySessionId++;
```

### 備考

実用上は約21億回の Play Mode 開始が必要なため、防御的な修正です。