### PR TITLE
refactor(SingletonBehaviour): Play セッションごとのソフトリセット実装

### DIFF
--- a/Foundation/Singletons/SingletonRuntime.cs
+++ b/Foundation/Singletons/SingletonRuntime.cs
@@ -4,7 +4,7 @@ namespace Foundation.Singletons
 {
     /// <summary>
     /// Central runtime lifecycle for singleton infrastructure.
-    /// Owns play-session initialization and quitting state.
+    /// Owns Play session initialization and quitting state.
     /// </summary>
     /// <remarks>
     /// Initialization runs at <see cref="RuntimeInitializeLoadType.SubsystemRegistration"/>,
@@ -28,7 +28,7 @@ namespace Foundation.Singletons
         /// Increments <see cref="PlaySessionId"/>, clears <see cref="IsQuitting"/>, and (re)subscribes to
         /// <see cref="Application.quitting"/> to avoid duplicate handlers when Domain Reload is disabled.
         /// </summary>
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        [RuntimeInitializeOnLoadMethod(loadType: RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Initialize()
         {
             if (PlaySessionId < int.MaxValue) PlaySessionId++;
@@ -42,6 +42,9 @@ namespace Foundation.Singletons
         /// <summary>
         /// Marks the runtime as quitting to prevent late singleton creation during shutdown.
         /// </summary>
-        private static void OnQuitting() => IsQuitting = true;
+        private static void OnQuitting()
+        {
+            IsQuitting = true;
+        }
     }
 }


### PR DESCRIPTION
### 概要

Scene Reload 無効時に同一オブジェクトが生存し続けるケースでも、Play セッションごとに `OnSingletonAwake` が確実に呼ばれるようソフトリセット方針を実装します。

### 背景

Enter Play Mode Options で Scene Reload を無効にすると、`DontDestroyOnLoad` されたオブジェクトが Play 停止後も生存し続ける場合があります。従来の `bool _isInitialized` では「一度でも初期化されたか」しか追跡できず、次の Play 開始時に `OnSingletonAwake` が呼ばれない問題がありました。

### 変更内容

#### 1. 初期化追跡の変更
```csharp
// Before
private bool _isInitialized;

// After
private int _initializedPlaySessionId = UninitializedPlaySessionId;
```

Play セッション ID と比較することで、セッションごとの再初期化を正確に追跡。

#### 2. メソッド名の変更
```csharp
// Before
private void TryInitializeOnce()

// After
private void TryInitializeForCurrentPlaySession()
```

ソフトリセット方針を反映した命名に変更。

#### 3. チェック順序の最適化
```csharp
// Before
1. IsQuitting チェック
2. 重複チェック（EnsurePlaySession 前）
3. EnsurePlaySession
4. 重複チェック（EnsurePlaySession 後）
5. CRTP チェック

// After
1. IsQuitting チェック
2. EnsurePlaySession（新 Play セッション優先）
3. CRTP チェック
4. 重複チェック
```

#### 4. XML ドキュメント更新
```csharp
/// 
/// Customization hook called once per Play session after the singleton is established and made persistent.
/// 
protected virtual void OnSingletonAwake()
```

### 動作の変更

| シナリオ | Before | After |
|----------|--------|-------|
| 通常の Play 開始 | `OnSingletonAwake` 1回 | `OnSingletonAwake` 1回 |
| Scene Reload 無効で再 Play | `OnSingletonAwake` 呼ばれない | `OnSingletonAwake` 1回 |

### 利用者への影響

`OnSingletonAwake` が Play セッションごとに呼ばれるため、以下を前提とした実装が推奨されます：

- イベント購読は二重登録防止を考慮
- キャッシュやコルーチンは再初期化を想定
- 状態リセットは `OnSingletonAwake` で行う

### テスト

- [x] Domain Reload: ON / Scene Reload: ON
- [x] Domain Reload: ON / Scene Reload: OFF
- [x] Domain Reload: OFF / Scene Reload: ON
- [x] Domain Reload: OFF / Scene Reload: OFF
- [x] 各パターンで `OnSingletonAwake` が Play ごとに1回呼ばれることを確認