### PR TITLE
refactor: 内部メソッド名を明確化

### DIFF
--- a/Foundation/Singletons/SingletonBehaviour.cs
+++ b/Foundation/Singletons/SingletonBehaviour.cs
@@ -32,7 +32,7 @@ namespace Foundation.Singletons
                     return Object.FindAnyObjectByType<T>(findObjectsInactive: FindInactivePolicy);
                 }
 
-                EnsurePlaySession();
+                InvalidateInstanceCacheIfPlaySessionChanged();
 
                 if (SingletonRuntime.IsQuitting) return null;
                 if (_instance != null) return _instance;
@@ -58,7 +58,7 @@ namespace Foundation.Singletons
                 return instance != null;
             }
 
-            EnsurePlaySession();
+            InvalidateInstanceCacheIfPlaySessionChanged();
 
             if (SingletonRuntime.IsQuitting)
             {
@@ -81,14 +81,14 @@ namespace Foundation.Singletons
         {
             if (!Application.isPlaying) return;
 
-            this.TryInitializeForCurrentPlaySession();
+            this.InitializeForCurrentPlaySessionIfNeeded();
         }
 
         private void OnEnable()
         {
             if (!Application.isPlaying) return;
 
-            this.TryInitializeForCurrentPlaySession();
+            this.InitializeForCurrentPlaySessionIfNeeded();
         }
 
         private void OnDestroy()
@@ -113,9 +113,9 @@ namespace Foundation.Singletons
         {
         }
 
-        private void TryInitializeForCurrentPlaySession()
+        private void InitializeForCurrentPlaySessionIfNeeded()
         {
-            EnsurePlaySession();
+            InvalidateInstanceCacheIfPlaySessionChanged();
 
             if (SingletonRuntime.IsQuitting)
             {
@@ -183,7 +183,7 @@ namespace Foundation.Singletons
             this._isPersistent = true;
         }
 
-        private static void EnsurePlaySession()
+        private static void InvalidateInstanceCacheIfPlaySessionChanged()
         {
             if (!Application.isPlaying) return;
 


### PR DESCRIPTION
## 概要

内部メソッド名を.NET命名規則と実際の動作に合わせて変更します。

## 変更内容

| 変更前 | 変更後 | 理由 |
|--------|--------|------|
| `EnsurePlaySession` | `InvalidateCacheIfPlaySessionChanged` | 「Ensure」は存在の保証を示唆するが、実際の動作はセッション変更の検出とキャッシュの無効化 |
| `TryInitializeForCurrentPlaySession` | `InitializeForCurrentPlaySessionIfNeeded` | `Try`プレフィックスは慣例的に`bool`戻り値と`out`引数を伴うパターンを示唆するが、このメソッドは`void`で失敗時は自己破棄する |

## 備考

- 内部メソッドのみの変更であり、公開APIに変更はありません
- 動作の変更はありません