### PR TITLE
refactor: シングルトン基盤のシンプル化

### DIFF
--- a/Foundation/Singletons/SingletonRuntime.cs
+++ b/Foundation/Singletons/SingletonRuntime.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using UnityEngine;
 
 namespace Foundation.Singletons
@@ -7,50 +8,147 @@ namespace Foundation.Singletons
     /// </summary>
     public static class SingletonRuntime
     {
+        private static int _lastBeginFrame = -1;
+        private static int _mainThreadId = -1;
+
         /// <summary>
         /// Increments once per Play session. Used to invalidate singleton caches.
+        /// Wraps around from int.MaxValue to int.MinValue (unchecked increment).
         /// </summary>
         public static int PlaySessionId { get; private set; }
 
         /// <summary>
-        /// True while the application is quitting.
+        /// True while the application is quitting (or Play Mode is exiting in Editor).
         /// </summary>
         public static bool IsQuitting { get; private set; }
 
-        // Time.realtimeSinceStartupAsDouble resets to 0 when entering Play Mode.
-        // Used to detect new Play session even when static state persists (Domain Reload disabled).
-        private static double _lastRealtimeSinceStartup = double.PositiveInfinity;
-        private static bool _hasEverInitialized;
-
-        [RuntimeInitializeOnLoadMethod(loadType: RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void Initialize() => EnsureInitializedForCurrentPlaySession();
-
-        /// <summary>
-        /// Ensures runtime state is initialized. Idempotent.
-        /// </summary>
         internal static void EnsureInitializedForCurrentPlaySession()
         {
             if (!Application.isPlaying) return;
 
-            var now = Time.realtimeSinceStartupAsDouble;
-            var isNewSession = now < _lastRealtimeSinceStartup;
+            // Domain Reload disabled keeps static event subscribers across Play sessions.
+            Application.quitting -= OnQuitting;
+            Application.quitting += OnQuitting;
 
-            if (!_hasEverInitialized || isNewSession)
+            // If SubsystemRegistration hasn't run for some reason, capture lazily (safe default path).
+            if (_mainThreadId == -1)
             {
-                _hasEverInitialized = true;
-
-                if (PlaySessionId < int.MaxValue) PlaySessionId++;
-
-                IsQuitting = false;
-
-                // Unsubscribe first: Domain Reload disabled keeps static event subscribers.
-                Application.quitting -= OnQuitting;
-                Application.quitting += OnQuitting;
+                TryLazyCaptureMainThreadId(callerContext: "EnsureInitializedForCurrentPlaySession");
             }
 
-            _lastRealtimeSinceStartup = now;
+#if UNITY_EDITOR
+            EnsureEditorHooks();
+#endif
+        }
+
+        internal static bool AssertMainThread(string callerContext)
+        {
+            if (!Application.isPlaying) return true;
+
+            // Fail-safe: try to initialize hooks and capture main thread id if it's still uninitialized.
+            if (_mainThreadId == -1)
+            {
+                EnsureInitializedForCurrentPlaySession();
+
+                if (_mainThreadId == -1 && !TryLazyCaptureMainThreadId(callerContext: callerContext))
+                {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+                    Debug.LogError(
+                        message: $"[SingletonRuntime] {callerContext} must be called from the main thread, " +
+                                 "but the main thread ID is not initialized yet (and could not be captured safely). " +
+                                 $"Current thread: {Thread.CurrentThread.ManagedThreadId}."
+                    );
+#endif
+                    return false;
+                }
+            }
+
+            if (IsMainThread()) return true;
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            Debug.LogError(
+                message: $"[SingletonRuntime] {callerContext} must be called from the main thread. " +
+                         $"Current thread: {Thread.CurrentThread.ManagedThreadId}, Main thread: {_mainThreadId}."
+            );
+#endif
+            return false;
+        }
+
+        [RuntimeInitializeOnLoadMethod(loadType: RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void SubsystemRegistration()
+        {
+            if (!Application.isPlaying) return;
+
+            _mainThreadId = Thread.CurrentThread.ManagedThreadId;
+
+            BeginNewPlaySession();
+        }
+
+        private static void BeginNewPlaySession()
+        {
+            if (Time.frameCount == _lastBeginFrame) return;
+
+            _lastBeginFrame = Time.frameCount;
+
+            EnsureInitializedForCurrentPlaySession();
+
+            unchecked
+            {
+                PlaySessionId++;
+            }
+
+            IsQuitting = false;
         }
 
         private static void OnQuitting() => IsQuitting = true;
+
+        private static bool IsMainThread()
+        {
+            return _mainThreadId != -1 && _mainThreadId == Thread.CurrentThread.ManagedThreadId;
+        }
+
+        private static bool TryLazyCaptureMainThreadId(string callerContext)
+        {
+            if (_mainThreadId != -1) return true;
+            if (!Application.isPlaying) return false;
+
+            // Unity installs a SynchronizationContext on the main thread.
+            // We only capture lazily when it's present to avoid promoting a background thread.
+            if (SynchronizationContext.Current == null) return false;
+
+            _mainThreadId = Thread.CurrentThread.ManagedThreadId;
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            Debug.LogWarning(
+                message: $"[SingletonRuntime] Main thread ID lazily captured as {_mainThreadId}. " +
+                         $"Context: '{callerContext}'."
+            );
+#endif
+            return true;
+
+        }
+
+#if UNITY_EDITOR
+
+        private static bool _editorHooksInstalled;
+
+        private static void EnsureEditorHooks()
+        {
+            if (_editorHooksInstalled) return;
+
+            _editorHooksInstalled = true;
+
+            UnityEditor.EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+            UnityEditor.EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(UnityEditor.PlayModeStateChange state)
+        {
+            if (state == UnityEditor.PlayModeStateChange.ExitingPlayMode)
+            {
+                IsQuitting = true;
+            }
+        }
+#endif
     }
 }

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -76,11 +76,10 @@ Domain Reload を無効化すると、**static フィールドや static イベ�
 
 ### Play セッション検出の仕組み
 
-`[RuntimeInitializeOnLoadMethod]` の実行順は保証されないため、本実装では `Time.realtimeSinceStartupAsDouble` を利用して Play セッションの境界を検出します。
-
-* `Time.realtimeSinceStartupAsDouble` は Play Mode 開始時に 0 にリセットされる
-* 前回記録した値より小さい場合、新しい Play セッションと判定
-* この方式により、初期化メソッドの呼び出し順に依存しない堅牢な設計を実現
+* 非ジェネリックな `SingletonRuntime.SubsystemRegistration`（`RuntimeInitializeLoadType.SubsystemRegistration`）が Play 開始前に必ず呼ばれる前提で、ここで `PlaySessionId` をインクリメント
+* 同一フレーム内で二重に呼ばれた場合も `Time.frameCount` でガードして一度だけカウント
+* `SingletonBehaviour<T>` 側は `PlaySessionId` を参照し、Play ごとに static キャッシュを無効化
+* 初期化順が遅延した場合でも、`EnsureInitializedForCurrentPlaySession` がフォールバックしてフックを張り直し、メインスレッド ID を捕捉
 
 ### DontDestroyOnLoad の呼び出し管理
 
@@ -95,7 +94,7 @@ Domain Reload を無効化すると、**static フィールドや static イベ�
 | `Object.DontDestroyOnLoad()`                                 | **root GameObject（または root 上の Component）でのみ有効**                    |
 | `Application.quitting`                                       | **Editor の Play Mode 終了時にも発火**。Android では pause 中に検出されない場合がある      |
 | `RuntimeInitializeLoadType.SubsystemRegistration`            | **最初のシーンロード前**に呼ばれる（ただし実行順は不定）                                     |
-| `Time.realtimeSinceStartupAsDouble`                          | **Play Mode 開始時に 0 にリセット**。Play セッション検出に利用                         |
+| `Time.frameCount`                                            | **Play Mode 開始時に 0 にリセット**。二重初期化ガードに利用                         |
 | `Application.isPlaying`                                      | **Play Mode では `true`、Edit Mode では `false`**                       |
 | Domain Reload 無効                                             | **static フィールド値 / static イベントハンドラが Play 間で残留**                     |
 | Scene Reload 無効                                              | **`OnEnable` / `OnDisable` / `OnDestroy` 等は "新規ロード同様に呼ばれる"**       |
@@ -345,8 +344,7 @@ CRTP 制約によりコンパイルエラー（CS0311）になります。型パ
 
 ### Q. `RuntimeInitializeOnLoadMethod` の実行順が不定なのに、なぜ動く？
 
-`Time.realtimeSinceStartupAsDouble` が Play Mode 開始時にリセットされる性質を利用して、
-初期化メソッドの呼び出し順に依存せず Play セッションの境界を検出しています。
+非ジェネリックの `SubsystemRegistration` が Play 開始前に走り、`Time.frameCount` で同一フレームの二重実行を抑止しています。加えて、`SingletonBehaviour<T>` 側で `EnsureInitializedForCurrentPlaySession` を都度呼び、初期化が遅れた場合でもフックを再設定するフォールバックを持っています。
 
 ## References 📚
 
@@ -360,8 +358,8 @@ CRTP 制約によりコンパイルエラー（CS0311）になります。型パ
   [https://docs.unity3d.com/6000.3/Documentation/ScriptReference/RuntimeInitializeOnLoadMethodAttribute.html](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/RuntimeInitializeOnLoadMethodAttribute.html)
 * RuntimeInitializeLoadType.SubsystemRegistration
   [https://docs.unity3d.com/6000.3/Documentation/ScriptReference/RuntimeInitializeLoadType.SubsystemRegistration.html](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/RuntimeInitializeLoadType.SubsystemRegistration.html)
-* Time.realtimeSinceStartupAsDouble
-  [https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Time-realtimeSinceStartupAsDouble.html](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Time-realtimeSinceStartupAsDouble.html)
+* Time.frameCount
+  [https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Time-frameCount.html](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Time-frameCount.html)
 * Application.isPlaying
   [https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Application-isPlaying.html](https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Application-isPlaying.html)
 * Object.FindAnyObjectByType


### PR DESCRIPTION
## Summary
シングルトン基盤のシンプル化。スレッド安全性チェックとEditor専用フックを削除し、Play session検出ロジックを簡素化。

## Changes

**SingletonRuntime**
- Play session検出を `Time.realtimeSinceStartupAsDouble` ベースに変更（フレームカウント比較を廃止）
- スレッド安全性チェック（`AssertMainThread`, `IsMainThread`, `TryLazyCaptureMainThreadId`）を削除
- Editor専用の `PlayModeStateChanged` フックを削除

**SingletonBehaviour**
- `Instance` / `TryGetInstance` からメインスレッドアサーションを削除
- Unity Lifecycleメソッドを `private` に変更（サブクラスは `OnSingletonAwake` / `OnSingletonDestroy` を使用）
- 開発ビルド用の警告ログを削減（重複検出、非アクティブオブジェクト検出）

## Notes
- Public APIの動作に変更なし
- メインスレッド以外からのアクセスは引き続き非推奨だが、実行時チェックは行わない