### PR TITLE
docs: streamline XML comments and reduce redundancy

### DIFF
--- a/Singletons/Core/SingletonBehaviour.cs
+++ b/Singletons/Core/SingletonBehaviour.cs
@@ -37,7 +37,6 @@ namespace Singletons.Core
 
         private static readonly TPolicy Policy = default;
 
-        // Per generic instantiation (T, TPolicy). Not shared across different T.
         // ReSharper disable once StaticMemberInGenericType
         private static T _instance;
 
@@ -48,7 +47,7 @@ namespace Singletons.Core
         private bool _isPersistent;
 
         /// <summary>
-        /// Returns singleton instance. Returns null during quit, from background thread, or if validation fails in release.
+        /// Returns singleton instance. In PlayMode, returns null during quit, from background thread, or if validation fails in release.
         /// </summary>
         public static T Instance
         {
@@ -79,7 +78,7 @@ namespace Singletons.Core
                 {
                     if (!candidate.isActiveAndEnabled)
                     {
-                        // In release: call stripped, returns null below.
+                        // In release: ThrowInvalidOperation call stripped, returns null below.
                         SingletonLogger.ThrowInvalidOperation(
                             message: $"Inactive/disabled instance detected.\nFound: '{candidate.name}' (type: '{candidate.GetType().Name}').\nEnable/activate it or remove it from the scene.",
                             typeTag: LogCategoryName
@@ -94,7 +93,6 @@ namespace Singletons.Core
 
                 if (!Policy.AutoCreateIfMissing)
                 {
-                    // In release: call stripped, returns null below.
                     SingletonLogger.ThrowInvalidOperation(
                         message: "No instance found and auto-creation is disabled by policy.\nPlace an active instance in the scene.",
                         typeTag: LogCategoryName
@@ -152,7 +150,6 @@ namespace Singletons.Core
             {
                 if (!candidate.isActiveAndEnabled)
                 {
-                    // In release: call stripped, returns false below.
                     SingletonLogger.ThrowInvalidOperation(
                         message: $"Inactive/disabled instance detected.\nFound: '{candidate.name}' (type: '{candidate.GetType().Name}').\nEnable/activate it or remove it from the scene.",
                         typeTag: LogCategoryName
@@ -231,7 +228,6 @@ namespace Singletons.Core
             var instance = go.AddComponent<T>();
             instance._isPersistent = Policy.PersistAcrossScenes;
 
-            // Ensure initialization even if derived Awake doesn't call base.
             instance.InitializeForCurrentPlaySessionIfNeeded();
 
             SingletonLogger.LogWarning(
@@ -266,7 +262,6 @@ namespace Singletons.Core
             return null;
         }
 
-        // In release: entire method call stripped, FindObjectsByType not executed.
         [System.Diagnostics.Conditional(conditionString: "UNITY_EDITOR"), System.Diagnostics.Conditional(conditionString: "DEVELOPMENT_BUILD")]
         private static void ThrowIfInactiveInstanceExists()
         {

--- a/Singletons/Core/SingletonRuntime.cs
+++ b/Singletons/Core/SingletonRuntime.cs
@@ -78,6 +78,9 @@ namespace Singletons.Core
             return false;
         }
 
+        /// <summary>
+        /// First reliable point in Play Mode where main thread ID can be captured.
+        /// </summary>
         [RuntimeInitializeOnLoadMethod(loadType: RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void SubsystemRegistration()
         {


### PR DESCRIPTION
## Summary

XMLドキュメントコメントとインラインコメントを精査し、冗長性を削減しました。

## Changes

### [SingletonBehaviour.cs](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons/Core/SingletonBehaviour.cs:0:0-0:0)
- **Instance summary改善**: `In PlayMode,` を追記し、EditMode時の挙動との違いを明確化
- **重複コメント削除**: `// In release: call stripped` コメントを3箇所→1箇所に集約
- **自明なコメント削除**:
  - L40: 静的フィールドの説明（クラスremarksの「Static isolation」で説明済み）
  - L234: [CreateInstance](cci:1://file:///c:/workspace/unity-singleton-behaviour/Singletons/Core/SingletonBehaviour.cs:218:8-239:9)内の初期化コメント（remarksで説明済み）
  - L269: `[Conditional]`属性上のコメント（属性自体が自明）

### [SingletonRuntime.cs](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons/Core/SingletonRuntime.cs:0:0-0:0)
- **SubsystemRegistration**にsummary追加: PlayModeでメインスレッドIDを取得する最初の信頼できるポイントであることを明記

## Impact

- **行数削減**: SingletonBehaviour.cs 374行 → 369行 (-5行)
- **コンテキストウィンドウ効率化**: AI解析時のトークン消費を軽減
- **機能変更なし**: ドキュメントのみの変更