### PR TITLE
feat: Add Assembly Definition for Singletons

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -48,6 +48,7 @@ MonoBehaviour 向けの **ポリシー駆動型シングルトン基底クラス
 
 ```text
 Singletons/
+├── Singletons.asmdef                 # Assembly Definition
 ├── PersistentSingletonBehaviour.cs   # Public API (永続・自動生成あり)
 ├── SceneSingletonBehaviour.cs        # Public API (シーン限定・自動生成なし)
 ├── Core/
@@ -58,7 +59,7 @@ Singletons/
     ├── ISingletonPolicy.cs           # ポリシーIF
     ├── PersistentPolicy.cs           # 永続ポリシーの実装
     └── SceneScopedPolicy.cs          # シーンスコープポリシーの実装
-````
+```
 
 ## Dependencies / 前提としている Unity API の挙動
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ They share the same core logic, while a **policy** controls the lifecycle behavi
 
 ```text
 Singletons/
+├── Singletons.asmdef                 # Assembly Definition
 ├── PersistentSingletonBehaviour.cs   # Public API (persistent + auto-create)
 ├── SceneSingletonBehaviour.cs        # Public API (scene-scoped + no auto-create)
 ├── Core/
@@ -58,7 +59,7 @@ Singletons/
     ├── ISingletonPolicy.cs           # Policy interface
     ├── PersistentPolicy.cs           # Persistent policy implementation
     └── SceneScopedPolicy.cs          # Scene-scoped policy implementation
-````
+```
 
 ## Dependencies (Assumed Unity API Behavior)
 

--- a/Singletons/Singletons.asmdef
+++ b/Singletons/Singletons.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Singletons",
+    "rootNamespace": "Singletons",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}


### PR DESCRIPTION
## Summary

Add Assembly Definition file to improve compilation performance and prepare for UPM compatibility.

## Changes

- **New file**: [Singletons/Singletons.asmdef](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons/Singletons.asmdef:0:0-0:0)
  - `autoReferenced: true` for seamless integration
  - Zero external dependencies
- **Updated**: README.md, README.ja.md
  - Added [Singletons.asmdef](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons/Singletons.asmdef:0:0-0:0) to directory structure section

## Benefits

- Faster incremental compilation (only recompile when Singletons code changes)
- Explicit dependency isolation
- Foundation for future Unity Package Manager (UPM) support