### PR TITLE
fix: Remove rootNamespace from asmdef to resolve IDE warnings

### DIFF
--- a/Singletons/Singletons.asmdef
+++ b/Singletons/Singletons.asmdef
@@ -1,6 +1,5 @@
 {
     "name": "Singletons",
-    "rootNamespace": "Singletons",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## Summary

Remove `rootNamespace` field from [Singletons.asmdef](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons/Singletons.asmdef:0:0-0:0) to resolve IDE namespace warnings.

## Problem

With `rootNamespace: "Singletons"` specified, Rider reported:
> 名前空間はファイルの場所に対応していません。'Singletons.Singletons.Core' であるべきです

## Solution

Remove the `rootNamespace` field entirely. Unity/Rider will derive namespaces from folder structure:
- [Singletons/](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons:0:0-0:0) → [Singletons](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons:0:0-0:0)
- [Singletons/Core/](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons/Core:0:0-0:0) → `Singletons.Core`
- [Singletons/Policy/](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons/Policy:0:0-0:0) → `Singletons.Policy`

## Changes

- **Modified**: [Singletons/Singletons.asmdef](cci:7://file:///c:/workspace/unity-singleton-behaviour/Singletons/Singletons.asmdef:0:0-0:0)
  - Removed `rootNamespace` field