### PR TITLE
refactor: extract editor hooks from SingletonRuntime to SingletonEdit…

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# ポリシー駆動型Unityシングルトン（v3.0.1）
+# ポリシー駆動型Unityシングルトン（v3.0.2）
 
 [English README](./README.md)
 
@@ -82,7 +82,9 @@ Singletons/
 ├── Core/
 │   ├── SingletonBehaviour.cs         # コア実装
 │   ├── SingletonRuntime.cs           # 内部ランタイム (Domain Reload対策)
-│   └── SingletonLogger.cs            # 条件付きロガー (リリースで除去)
+│   ├── SingletonLogger.cs            # 条件付きロガー (リリースで除去)
+│   └── Editor/
+│       └── SingletonEditorHooks.cs   # Editorイベントフック (Play Mode状態)
 ├── Policy/
 │   ├── ISingletonPolicy.cs           # ポリシーIF
 │   ├── PersistentPolicy.cs           # 永続ポリシーの実装

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Policy-Driven Unity Singleton (v3.0.1)
+# Policy-Driven Unity Singleton (v3.0.2)
 
 [Japanese README](./README.ja.md)
 
@@ -82,7 +82,9 @@ Singletons/
 ├── Core/
 │   ├── SingletonBehaviour.cs         # Core implementation
 │   ├── SingletonRuntime.cs           # Internal runtime (Domain Reload handling)
-│   └── SingletonLogger.cs            # Conditional logger (stripped in release)
+│   ├── SingletonLogger.cs            # Conditional logger (stripped in release)
+│   └── Editor/
+│       └── SingletonEditorHooks.cs   # Editor event hooks (Play Mode state)
 ├── Policy/
 │   ├── ISingletonPolicy.cs           # Policy interface
 │   ├── PersistentPolicy.cs           # Persistent policy implementation

--- a/Singletons/Core/Editor/SingletonEditorHooks.cs
+++ b/Singletons/Core/Editor/SingletonEditorHooks.cs
@@ -1,0 +1,25 @@
+using UnityEditor;
+
+namespace Singletons.Core.Editor
+{
+    /// <summary>
+    /// Registers Editor event hooks for singleton infrastructure.
+    /// </summary>
+    [InitializeOnLoad]
+    internal static class SingletonEditorHooks
+    {
+        static SingletonEditorHooks()
+        {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.ExitingPlayMode)
+            {
+                SingletonRuntime.NotifyQuitting();
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unity-policy-singleton",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "displayName": "Policy-Driven Singleton",
     "description": "A policy-driven singleton base class for MonoBehaviour with Domain Reload support.",
     "unity": "2022.3",


### PR DESCRIPTION
## Summary

Refactors editor-specific code by extracting Play Mode state handling from [SingletonRuntime](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:12:4-119:5) to a dedicated [SingletonEditorHooks](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/Editor/SingletonEditorHooks.cs:7:4-23:5) class.

## Changes

### Code Refactoring

- **Renamed** [SingletonEditorIntegration](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/Editor/SingletonEditorIntegration.cs:8:4-24:5) → [SingletonEditorHooks](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/Editor/SingletonEditorHooks.cs:7:4-23:5)
  - Better reflects the class's responsibility (registering editor event hooks)
  
- **Extracted editor hooks** from [SingletonRuntime](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:12:4-119:5)
  - Moved `playModeStateChanged` handling to [SingletonEditorHooks](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/Editor/SingletonEditorHooks.cs:7:4-23:5)
  - Uses `[InitializeOnLoad]` for automatic registration (no manual initialization needed)
  - Removed all `#if UNITY_EDITOR` preprocessor directives from [SingletonRuntime](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:12:4-119:5)

- **Added** [NotifyQuitting()](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:78:8-81:67) internal method to [SingletonRuntime](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:12:4-119:5)
  - Allows [SingletonEditorHooks](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/Editor/SingletonEditorHooks.cs:7:4-23:5) to signal quit state

### Code Quality Improvements

- **Reordered methods** in [SingletonRuntime](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:12:4-119:5) following C# conventions:
  - Constants → Fields → Properties → Internal Methods → Private Methods
  
- **Added XML documentation** to internal methods:
  - [EnsureInitializedForCurrentPlaySession()](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:32:8-47:9)
  - [ValidateMainThread()](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:49:8-76:9)
  - [NotifyQuitting()](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:78:8-81:67)

- **Removed redundant** `#if UNITY_EDITOR` from [SingletonEditorHooks.cs](cci:7://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/Editor/SingletonEditorHooks.cs:0:0-0:0)
  - Files in Editor folders are automatically excluded from runtime builds

### Documentation

- Updated directory structure in [README.md](cci:7://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/README.md:0:0-0:0) and [README.ja.md](cci:7://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/README.ja.md:0:0-0:0)

## Benefits

- Cleaner separation of concerns (runtime vs editor code)
- No preprocessor directives in [SingletonRuntime](cci:2://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:12:4-119:5)
- Better code organization following C# best practices
- Improved maintainability for future editor extensions