### PR TITLE
feat(tests): add comprehensive Edit Mode and Domain Reload tests

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# ポリシー駆動型Unityシングルトン（v3.0.2）
+# ポリシー駆動型Unityシングルトン（v3.0.3）
 
 [English README](./README.md)
 
@@ -409,9 +409,9 @@ Edit Mode（`Application.isPlaying == false`）では、次の挙動に固定し
 
 ### 同梱テスト
 
-本パッケージには包括的な PlayMode および EditMode テストが含まれ、**53個の総テスト**（PlayMode 41個 + EditMode 12個）すべて成功しています。
+本パッケージには包括的な PlayMode および EditMode テストが含まれ、**73個の総テスト**（PlayMode 53個 + EditMode 20個）すべて成功しています。
 
-#### PlayMode テスト（41個）
+#### PlayMode テスト（53個）
 
 | カテゴリ | テスト数 | カバレッジ |
 |---------|---------|----------|
@@ -426,14 +426,21 @@ Edit Mode（`Application.isPlaying == false`）では、次の挙動に固定し
 | PracticalUsage | 6 | GameManager、LevelController、状態管理 |
 | PolicyBehavior | 3 | ポリシー駆動挙動検証 |
 | ResourceManagement | 3 | インスタンスライフサイクルとクリーンアップ |
+| DomainReload | 6 | PlaySessionId境界、キャッシュ無効化、終了状態 |
+| ParentHierarchy | 2 | DontDestroyOnLoad用のルート再配置 |
+| BaseAwakeEnforcement | 1 | base.Awake() 呼び出し検出 |
+| EdgeCase | 3 | 破棄インスタンスクリーンアップ、高速アクセス、配置タイミング |
 
-#### EditMode テスト（12個）
+#### EditMode テスト（20個）
 
 | カテゴリ | テスト数 | カバレッジ |
 |---------|---------|----------|
 | SingletonRuntimeEditMode | 2 | PlaySessionId、IsQuitting 検証 |
 | Policy | 5 | Policy struct 検証、不変性、インターフェース準拠 |
 | SingletonBehaviourEditMode | 5 | EditMode 挙動、キャッシュ分離 |
+| SingletonLifecycleEditMode | 3 | 親階層、生成、Edit Modeでの共存 |
+| SingletonRuntimeStateEditMode | 2 | NotifyQuitting、PlaySessionId一貫性 |
+| SingletonLoggerEditMode | 3 | LogWarning、LogError、ThrowInvalidOperation API |
 
 ### テストの実行
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Policy-Driven Unity Singleton (v3.0.2)
+# Policy-Driven Unity Singleton (v3.0.3)
 
 [Japanese README](./README.ja.md)
 
@@ -409,9 +409,9 @@ This is **intended behavior** for this singleton design, so align your team on o
 
 ### Included Tests
 
-This package includes comprehensive PlayMode and EditMode tests with **53 total tests** (41 PlayMode + 12 EditMode), all passing.
+This package includes comprehensive PlayMode and EditMode tests with **73 total tests** (53 PlayMode + 20 EditMode), all passing.
 
-#### PlayMode Tests (41 tests)
+#### PlayMode Tests (53 tests)
 
 | Category | Tests | Coverage |
 |----------|-------|----------|
@@ -426,14 +426,21 @@ This package includes comprehensive PlayMode and EditMode tests with **53 total 
 | PracticalUsage | 6 | GameManager, LevelController, state management |
 | PolicyBehavior | 3 | Policy-driven behavior validation |
 | ResourceManagement | 3 | Instance lifecycle and cleanup |
+| DomainReload | 6 | PlaySessionId boundary, cache invalidation, quitting state |
+| ParentHierarchy | 2 | Root reparenting for DontDestroyOnLoad |
+| BaseAwakeEnforcement | 1 | base.Awake() call detection |
+| EdgeCase | 3 | Destroyed instance cleanup, rapid access, placement timing |
 
-#### EditMode Tests (12 tests)
+#### EditMode Tests (20 tests)
 
 | Category | Tests | Coverage |
 |----------|-------|----------|
 | SingletonRuntimeEditMode | 2 | PlaySessionId, IsQuitting validation |
 | Policy | 5 | Policy struct validation, immutability, interface compliance |
 | SingletonBehaviourEditMode | 5 | EditMode behavior, caching isolation |
+| SingletonLifecycleEditMode | 3 | Parent hierarchy, creation, coexistence in Edit Mode |
+| SingletonRuntimeStateEditMode | 2 | NotifyQuitting, PlaySessionId consistency |
+| SingletonLoggerEditMode | 3 | LogWarning, LogError, ThrowInvalidOperation APIs |
 
 ### Running Tests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unity-policy-singleton",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "displayName": "Policy-Driven Singleton",
     "description": "A policy-driven singleton base class for MonoBehaviour with Domain Reload support.",
     "unity": "2022.3",


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for Edit Mode and Domain Reload scenarios in the Unity Singleton framework.

## Changes

### New Test Fixtures

#### Edit Mode Tests ([EditModeTests.cs](cci:7://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/Editor/EditModeTests.cs:0:0-0:0))
- **SingletonLifecycleEditModeTests**: Tests for singleton creation, parent hierarchy, and multiple singleton coexistence in Edit Mode
- **SingletonRuntimeStateEditModeTests**: Tests for `IsQuitting` flag and `PlaySessionId` consistency
- **SingletonLoggerEditModeTests**: Tests for [LogWarning](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonLogger.cs:19:8-26:9), [LogError](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonLogger.cs:46:8-53:9), and [ThrowInvalidOperation](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonLogger.cs:55:8-62:9) APIs

#### Runtime Tests ([SingletonTests.cs](cci:7://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/Runtime/SingletonTests.cs:0:0-0:0))
- **DomainReloadTests**: Tests for Play session boundary handling when Domain Reload is disabled
  - Static cache invalidation on PlaySessionId change
  - [OnPlaySessionStart](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonBehaviour.cs:181:8-186:9) callback behavior
  - Awake count verification across boundaries
  - Quitting state behavior
- **ParentHierarchyTests**: Tests for persistent singleton reparenting to root
- **BaseAwakeEnforcementTests**: Tests for [base.Awake()](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/Runtime/SingletonTests.cs:715:8-721:9) call detection
- **EdgeCaseTests**: Tests for destroyed instance cleanup, rapid access, and SceneSingleton placement

### Bug Fixes
- Fixed `MissingReferenceException` in TearDown by adding null check
- Fixed unhandled error log in [LogError_WithTypeParameter_FormatsCorrectly](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/Editor/EditModeTests.cs:332:8-342:9) test
- Fixed test isolation issue where `IsQuitting` flag prevented proper cleanup

## Test Results
- **Edit Mode**: 20 tests (all passing)
- **Play Mode**: 53 tests (all passing)

## Checklist
- [x] All new tests pass
- [x] Existing tests remain passing
- [x] Test cleanup properly isolates test state