### PR TITLE
feat: Add Debug Logging for Singleton Lifecycle Events

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# ポリシー駆動型Unityシングルトン（v3.0.3）
+# ポリシー駆動型Unityシングルトン（v3.0.4）
 
 [English README](./README.md)
 
@@ -409,7 +409,7 @@ Edit Mode（`Application.isPlaying == false`）では、次の挙動に固定し
 
 ### 同梱テスト
 
-本パッケージには包括的な PlayMode および EditMode テストが含まれ、**73個の総テスト**（PlayMode 53個 + EditMode 20個）すべて成功しています。
+本パッケージには包括的な PlayMode および EditMode テストが含まれ、**74個の総テスト**（PlayMode 53個 + EditMode 21個）すべて成功しています。
 
 #### PlayMode テスト（53個）
 
@@ -431,7 +431,7 @@ Edit Mode（`Application.isPlaying == false`）では、次の挙動に固定し
 | BaseAwakeEnforcement | 1 | base.Awake() 呼び出し検出 |
 | EdgeCase | 3 | 破棄インスタンスクリーンアップ、高速アクセス、配置タイミング |
 
-#### EditMode テスト（20個）
+#### EditMode テスト（21個）
 
 | カテゴリ | テスト数 | カバレッジ |
 |---------|---------|----------|
@@ -440,7 +440,7 @@ Edit Mode（`Application.isPlaying == false`）では、次の挙動に固定し
 | SingletonBehaviourEditMode | 5 | EditMode 挙動、キャッシュ分離 |
 | SingletonLifecycleEditMode | 3 | 親階層、生成、Edit Modeでの共存 |
 | SingletonRuntimeStateEditMode | 2 | NotifyQuitting、PlaySessionId一貫性 |
-| SingletonLoggerEditMode | 3 | LogWarning、LogError、ThrowInvalidOperation API |
+| SingletonLoggerEditMode | 4 | Log、LogWarning、LogError、ThrowInvalidOperation API |
 
 ### テストの実行
 
@@ -522,13 +522,24 @@ DEV/EDITORでのfail-fast動作によるものです。SceneSingletonがシー�
 **Q. SceneSingletonをシーンに置き忘れたらどうなりますか？**
 DEV/EDITORでは例外、Playerでは`null`/`false`を返します。GlobalSingletonは見つからなければ自動生成されます。
 
+### 組み込みデバッグログ
+
+本ライブラリは `UNITY_EDITOR` および `DEVELOPMENT_BUILD` でのみデバッグログを出力します（リリースビルドではストリップ）：
+
+| レベル | メッセージ | トリガー |
+|--------|---------|--------|
+| **Log** | `OnPlaySessionStart invoked.` | シングルトンのセッションごとの初期化実行時 |
+| **Log** | `Instance access blocked: application is quitting.` | 終了中に `Instance` が null を返す時 |
+| **Log** | `TryGetInstance blocked: application is quitting.` | 終了中に `TryGetInstance` が false を返す時 |
+| **Warning** | `Auto-created.` | GlobalSingleton が自動生成された時 |
+| **Warning** | `Duplicate detected.` | 重複シングルトンが破棄された時 |
+| **Warning** | `Reparented to root for DontDestroyOnLoad.` | 親オブジェクト下の永続シングルトンがルートに再配置された時 |
+| **Error** | `base.Awake() was not called` | サブクラスが `base.Awake()` を呼び忘れた時 |
+| **Error** | `Type mismatch` | 正確な型ではなく派生クラスが見つかった時 |
+
 ### デバッグヒント
 
 ```csharp
-// 詳細ログを有効化（DEV/EDITORのみ）
-#define DEVELOPMENT_BUILD
-#define UNITY_EDITOR
-
 // シングルトン状態を確認
 if (MySingleton.TryGetInstance(out var instance))
 {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Policy-Driven Unity Singleton (v3.0.3)
+# Policy-Driven Unity Singleton (v3.0.4)
 
 [Japanese README](./README.ja.md)
 
@@ -409,7 +409,7 @@ This is **intended behavior** for this singleton design, so align your team on o
 
 ### Included Tests
 
-This package includes comprehensive PlayMode and EditMode tests with **73 total tests** (53 PlayMode + 20 EditMode), all passing.
+This package includes comprehensive PlayMode and EditMode tests with **74 total tests** (53 PlayMode + 21 EditMode), all passing.
 
 #### PlayMode Tests (53 tests)
 
@@ -431,7 +431,7 @@ This package includes comprehensive PlayMode and EditMode tests with **73 total 
 | BaseAwakeEnforcement | 1 | base.Awake() call detection |
 | EdgeCase | 3 | Destroyed instance cleanup, rapid access, placement timing |
 
-#### EditMode Tests (20 tests)
+#### EditMode Tests (21 tests)
 
 | Category | Tests | Coverage |
 |----------|-------|----------|
@@ -440,7 +440,7 @@ This package includes comprehensive PlayMode and EditMode tests with **73 total 
 | SingletonBehaviourEditMode | 5 | EditMode behavior, caching isolation |
 | SingletonLifecycleEditMode | 3 | Parent hierarchy, creation, coexistence in Edit Mode |
 | SingletonRuntimeStateEditMode | 2 | NotifyQuitting, PlaySessionId consistency |
-| SingletonLoggerEditMode | 3 | LogWarning, LogError, ThrowInvalidOperation APIs |
+| SingletonLoggerEditMode | 4 | Log, LogWarning, LogError, ThrowInvalidOperation APIs |
 
 ### Running Tests
 
@@ -522,13 +522,24 @@ Initialization is deferred and occurs on the first `Instance` / `TryGetInstance`
 **Q. What happens if I forget to place a SceneSingleton in the scene?**
 DEV/EDITOR throws an exception; Player builds return `null` / `false`. GlobalSingleton auto-creates if not found.
 
+### Built-in Debug Logging
+
+The library outputs debug logs in `UNITY_EDITOR` and `DEVELOPMENT_BUILD` only (stripped in release builds):
+
+| Level | Message | Trigger |
+|-------|---------|--------|
+| **Log** | `OnPlaySessionStart invoked.` | When a singleton's per-session initialization runs |
+| **Log** | `Instance access blocked: application is quitting.` | When `Instance` returns null due to quitting |
+| **Log** | `TryGetInstance blocked: application is quitting.` | When `TryGetInstance` returns false due to quitting |
+| **Warning** | `Auto-created.` | When a GlobalSingleton is auto-created |
+| **Warning** | `Duplicate detected.` | When a duplicate singleton is destroyed |
+| **Warning** | `Reparented to root for DontDestroyOnLoad.` | When a persistent singleton under a parent is reparented |
+| **Error** | `base.Awake() was not called` | When a subclass forgets to call `base.Awake()` |
+| **Error** | `Type mismatch` | When a derived class is found instead of exact type |
+
 ### Debugging Tips
 
 ```csharp
-// Enable detailed logging (DEV/EDITOR only)
-#define DEVELOPMENT_BUILD
-#define UNITY_EDITOR
-
 // Check singleton state
 if (MySingleton.TryGetInstance(out var instance))
 {

--- a/Singletons/Core/SingletonBehaviour.cs
+++ b/Singletons/Core/SingletonBehaviour.cs
@@ -52,7 +52,11 @@ namespace Singletons.Core
 
                 InvalidateInstanceCacheIfPlaySessionChanged();
 
-                if (SingletonRuntime.IsQuitting) return null;
+                if (SingletonRuntime.IsQuitting)
+                {
+                    SingletonLogger.Log<T>(message: "Instance access blocked: application is quitting.");
+                    return null;
+                }
                 if (HasCachedInstance) return _instance;
 
                 var candidate = FindAnyObjectByType<T>(findObjectsInactive: FindInactivePolicy);
@@ -108,6 +112,7 @@ namespace Singletons.Core
 
             if (SingletonRuntime.IsQuitting)
             {
+                SingletonLogger.Log<T>(message: "TryGetInstance blocked: application is quitting.");
                 instance = null;
                 return false;
             }
@@ -262,6 +267,7 @@ namespace Singletons.Core
 
             this.EnsurePersistent();
             this._initializedPlaySessionId = currentPlaySessionId;
+            SingletonLogger.Log<T>(message: "OnPlaySessionStart invoked.", context: this);
             this.OnPlaySessionStart();
         }
 

--- a/Singletons/Core/SingletonLogger.cs
+++ b/Singletons/Core/SingletonLogger.cs
@@ -18,6 +18,15 @@ namespace Singletons.Core
         private const string DevBuildSymbol = "DEVELOPMENT_BUILD";
 
         /// <summary>
+        /// Logs an info message with automatic type tag resolution. Stripped in release builds.
+        /// </summary>
+        [Conditional(conditionString: EditorSymbol), Conditional(conditionString: DevBuildSymbol)]
+        public static void Log<T>(string message, UnityEngine.Object context = null)
+        {
+            Debug.Log(message: $"[{typeof(T).FullName}] {message}", context: context);
+        }
+
+        /// <summary>
         /// Logs a warning for infrastructure components. Stripped in release builds.
         /// </summary>
         [Conditional(conditionString: EditorSymbol), Conditional(conditionString: DevBuildSymbol)]

--- a/Singletons/Core/SingletonRuntime.cs
+++ b/Singletons/Core/SingletonRuntime.cs
@@ -105,7 +105,7 @@ namespace Singletons.Core
             IsQuitting = false;
         }
 
-        private static void OnQuitting() => IsQuitting = true;
+        private static void OnQuitting() => NotifyQuitting();
 
         private static bool TryLazyCaptureMainThreadId(string callerContext)
         {

--- a/Singletons/Tests/Editor/EditModeTests.cs
+++ b/Singletons/Tests/Editor/EditModeTests.cs
@@ -320,10 +320,23 @@ namespace Singletons.Tests.Editor
     public class SingletonLoggerEditModeTests
     {
         [Test]
+        public void Log_WithTypeParameter_FormatsCorrectly()
+        {
+            // Expect the log to avoid test failure
+            LogAssert.Expect(type: LogType.Log, message: "[Singletons.Tests.Editor.TestPersistentSingletonForEditMode] Test info message");
+
+            Assert.DoesNotThrow(() =>
+            {
+                SingletonLogger.Log<TestPersistentSingletonForEditMode>(message: "Test info message");
+            });
+        }
+
+        [Test]
         public void LogWarning_WithTypeParameter_FormatsCorrectly()
         {
-            // This test verifies that the logger can be called without exceptions
-            // Actual log output verification would require LogAssert in PlayMode
+            // Expect the warning log to avoid test failure
+            LogAssert.Expect(type: LogType.Warning, message: "[Singletons.Tests.Editor.TestPersistentSingletonForEditMode] Test warning message");
+
             Assert.DoesNotThrow(() =>
             {
                 SingletonLogger.LogWarning<TestPersistentSingletonForEditMode>(message: "Test warning message");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unity-policy-singleton",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "displayName": "Policy-Driven Singleton",
     "description": "A policy-driven singleton base class for MonoBehaviour with Domain Reload support.",
     "unity": "2022.3",


### PR DESCRIPTION
## Summary

This PR adds targeted debug logging to improve visibility into singleton lifecycle events, particularly useful for debugging Domain Reload disabled scenarios.

## Changes

### New Features
- **[SingletonLogger.Log<T>](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonLogger.cs:19:8-26:9)**: New Info-level logging method with automatic type tag resolution
- **OnPlaySessionStart logging**: Logs when each singleton's per-session initialization runs
- **IsQuitting state logging**: Logs when `Instance`/[TryGetInstance](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonBehaviour.cs:91:8-148:9) access is blocked due to application quitting

### Refactoring
- [OnQuitting()](cci:1://file:///c:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:107:8-107:61) now delegates to [NotifyQuitting()](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:78:8-81:67) to eliminate code duplication

### Tests
- Added [Log_WithTypeParameter_FormatsCorrectly](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/Editor/EditModeTests.cs:321:8-331:9) test
- Fixed [LogWarning](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonLogger.cs:37:8-44:9) test to use `LogAssert.Expect`
- **Total tests: 74** (53 PlayMode + 21 EditMode)

### Documentation
- Added "Built-in Debug Logging" section to both README.md and README.ja.md
- Updated test counts in README

## Log Output Examples
[MyNamespace.GameManager] OnPlaySessionStart invoked. [MyNamespace.GameManager] Instance access blocked: application is quitting.
 
All logs are conditional on `UNITY_EDITOR` or `DEVELOPMENT_BUILD` and stripped in release builds.
 
## Breaking Changes
 
None.
