### PR TITLE
Fix Directory Structure Documentation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# ポリシー駆動型Unityシングルトン（v3.0.4）
+# ポリシー駆動型Unityシングルトン（v3.0.5）
 
 [English README](./README.md)
 
@@ -75,27 +75,28 @@ MonoBehaviour 向けの **ポリシー駆動型シングルトン基底クラス
 
 ```text
 Singletons/
-├── Singletons.asmdef                 # Assembly Definition
-├── AssemblyInfo.cs                   # InternalsVisibleTo（テスト用）
-├── GlobalSingleton.cs                # Public API (永続・自動生成あり)
-├── SceneSingleton.cs                 # Public API (シーン限定・自動生成なし)
+├── Singletons.asmdef                       # Assembly Definition
+├── AssemblyInfo.cs                         # InternalsVisibleTo（テスト用）
+├── GlobalSingleton.cs                      # Public API（永続・自動生成あり）
+├── SceneSingleton.cs                       # Public API（シーン限定・自動生成なし）
 ├── Core/
-│   ├── SingletonBehaviour.cs         # コア実装
-│   ├── SingletonRuntime.cs           # 内部ランタイム (Domain Reload対策)
-│   ├── SingletonLogger.cs            # 条件付きロガー (リリースで除去)
+│   ├── SingletonBehaviour.cs               # コア実装
+│   ├── SingletonRuntime.cs                 # 内部ランタイム（Domain Reload対策）
+│   ├── SingletonLogger.cs                  # 条件付きロガー（リリースで除去）
 │   └── Editor/
-│       └── SingletonEditorHooks.cs   # Editorイベントフック (Play Mode状態)
+│       └── SingletonEditorHooks.cs         # Editorイベントフック（Play Mode状態）
 ├── Policy/
-│   ├── ISingletonPolicy.cs           # ポリシーIF
-│   ├── PersistentPolicy.cs           # 永続ポリシーの実装
-│   └── SceneScopedPolicy.cs          # シーンスコープポリシーの実装
-└── Tests/                            # PlayMode & EditMode テスト
-    ├── Runtime/
-    │   ├── Singletons.Tests.asmdef
-    │   └── SingletonTests.cs
-    └── Editor/
-        ├── Singletons.Editor.Tests.asmdef
-        └── EditModeTests.cs
+│   ├── ISingletonPolicy.cs                 # ポリシーインターフェース
+│   ├── PersistentPolicy.cs                 # 永続ポリシーの実装
+│   └── SceneScopedPolicy.cs                # シーンスコープポリシーの実装
+└── Tests/                                  # PlayMode & EditMode テスト
+    ├── TestExtensions.cs                   # テストヘルパー
+    ├── Editor/
+    │   ├── Singletons.Editor.Tests.asmdef  # Editor用アセンブリ定義
+    │   └── EditModeTests.cs                # EditModeテスト
+    └── Runtime/
+        ├── Singletons.Tests.asmdef         # Runtime用アセンブリ定義
+        └── SingletonTests.cs               # PlayModeテスト
 ```
 
 ## Dependencies / 前提としている Unity API の挙動

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Policy-Driven Unity Singleton (v3.0.4)
+# Policy-Driven Unity Singleton (v3.0.5)
 
 [Japanese README](./README.ja.md)
 
@@ -75,27 +75,28 @@ They share the same core logic, while a **policy** controls the lifecycle behavi
 
 ```text
 Singletons/
-├── Singletons.asmdef                 # Assembly Definition
-├── AssemblyInfo.cs                   # InternalsVisibleTo for tests
-├── GlobalSingleton.cs                # Public API (persistent + auto-create)
-├── SceneSingleton.cs                 # Public API (scene-scoped + no auto-create)
+├── Singletons.asmdef                       # Assembly Definition
+├── AssemblyInfo.cs                         # InternalsVisibleTo (for tests)
+├── GlobalSingleton.cs                      # Public API (persistent + auto-create)
+├── SceneSingleton.cs                       # Public API (scene-scoped + no auto-create)
 ├── Core/
-│   ├── SingletonBehaviour.cs         # Core implementation
-│   ├── SingletonRuntime.cs           # Internal runtime (Domain Reload handling)
-│   ├── SingletonLogger.cs            # Conditional logger (stripped in release)
+│   ├── SingletonBehaviour.cs               # Core implementation
+│   ├── SingletonRuntime.cs                 # Internal runtime (Domain Reload handling)
+│   ├── SingletonLogger.cs                  # Conditional logger (stripped in release)
 │   └── Editor/
-│       └── SingletonEditorHooks.cs   # Editor event hooks (Play Mode state)
+│       └── SingletonEditorHooks.cs         # Editor event hooks (Play Mode state)
 ├── Policy/
-│   ├── ISingletonPolicy.cs           # Policy interface
-│   ├── PersistentPolicy.cs           # Persistent policy implementation
-│   └── SceneScopedPolicy.cs          # Scene-scoped policy implementation
-└── Tests/                            # PlayMode & EditMode tests
-    ├── Runtime/
-    │   ├── Singletons.Tests.asmdef
-    │   └── SingletonTests.cs
-    └── Editor/
-        ├── Singletons.Editor.Tests.asmdef
-        └── EditModeTests.cs
+│   ├── ISingletonPolicy.cs                 # Policy interface
+│   ├── PersistentPolicy.cs                 # Persistent policy implementation
+│   └── SceneScopedPolicy.cs                # Scene-scoped policy implementation
+└── Tests/                                  # PlayMode & EditMode tests
+    ├── TestExtensions.cs                   # Test helpers
+    ├── Editor/
+    │   ├── Singletons.Editor.Tests.asmdef  # Editor test assembly
+    │   └── EditModeTests.cs                # EditMode tests
+    └── Runtime/
+        ├── Singletons.Tests.asmdef         # Runtime test assembly
+        └── SingletonTests.cs               # PlayMode tests
 ```
 
 ## Dependencies (Assumed Unity API Behavior)

--- a/Singletons/Core/SingletonBehaviour.cs
+++ b/Singletons/Core/SingletonBehaviour.cs
@@ -68,7 +68,7 @@ namespace Singletons.Core
                     {
                         // In release: ThrowInvalidOperation call stripped, returns null below.
                         SingletonLogger.ThrowInvalidOperation<T>(message: $"Inactive/disabled instance detected.\nFound: '{candidate.name}' (type: '{candidate.GetType().Name}').\nEnable/activate it or remove it from the scene.");
-                    return null;
+                        return null;
                     }
 
                     candidate.InitializeForCurrentPlaySessionIfNeeded();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unity-policy-singleton",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "displayName": "Policy-Driven Singleton",
     "description": "A policy-driven singleton base class for MonoBehaviour with Domain Reload support.",
     "unity": "2022.3",


### PR DESCRIPTION
## Summary
This PR fixes inconsistencies between the actual directory structure and the README documentation, and unifies the comment style across both English and Japanese READMEs.

## Changes
### Directory Structure Fixes
- **README.md**: Added missing [TestExtensions.cs](cci:7://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/TestExtensions.cs:0:0-0:0) entry
### Comment Style Unification
- Aligned all comments to column 41 in both READMEs
- Added comments to previously uncommented files:
- Standardized Japanese parentheses to full-width `（）`

## Before/After
**Before (README.md)**:
```text
└── Tests/
    ├── Runtime/
    │   ├── Singletons.Tests.asmdef
    │   └── SingletonTests.cs
    └── Editor/
        ├── Singletons.Editor.Tests.asmdef
        └── EditModeTests.cs
```

After (Both READMEs):
```text
└── Tests/
    ├── TestExtensions.cs                   # Test helpers
    ├── Editor/
    │   ├── Singletons.Editor.Tests.asmdef  # Editor test assembly
    │   └── EditModeTests.cs                # EditMode tests
    └── Runtime/
        ├── Singletons.Tests.asmdef         # Runtime test assembly
        └── SingletonTests.cs               # PlayMode tests
```

### Breaking Changes
None.