### PR TITLE
Fix: Prevent UnityException on Background Thread Singleton Access

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# ポリシー駆動型Unityシングルトン（v3.0.6）
+# ポリシー駆動型Unityシングルトン（v3.1.0）
 
 [English README](./README.md)
 
@@ -163,7 +163,7 @@ classDiagram
     │  PlaySessionId: 1   │              │  PlaySessionId: 2   │
     │  _instance: 0xABC   │              │  _instance: 0xABC   │ (same object)
     └─────────────────────┘              └─────────────────────┘
-              │                                    │
+              │                                  │
     ┌─────────▼─────────┐              ┌─────────▼─────────┐
     │ Static cache OK   │              │ Static cache OK   │
     │ Instance: 0xABC   │   ───────▶   │ Instance: 0xABC   │ (same object)
@@ -613,7 +613,7 @@ public void TearDown()
 シングルトンクラスに静的コンストラクタがある場合、`PlaySessionId`が初期化される前に実行される可能性があります。これにより、まれに予期しない動作を引き起こすことがあります。
 
 ### スレッドセーフティ
-すべてのシングルトン操作はメインスレッドから呼び出す必要があります。バックグラウンドスレッドからのアクセスは `UnityException` をスローします（`Application.isPlaying` がメインスレッド専用APIのため）。
+すべてのシングルトン操作はメインスレッドから呼び出す必要があります。バックグラウンドスレッドからのアクセスは例外をスローせず、`null` / `false` を返します。これにより、Unityバージョン間で安定した動作を保証します。
 
 ### シーン読み込み順序
 複数のシーンに同じシングルトンタイプが含まれる場合、破棄順序はUnityのシーン読み込みシーケンスに依存します。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Policy-Driven Unity Singleton (v3.0.6)
+# Policy-Driven Unity Singleton (v3.1.0)
 
 [Japanese README](./README.ja.md)
 
@@ -161,7 +161,7 @@ classDiagram
     ┌─────────────────────┐              ┌─────────────────────┐
     │  PlaySessionId: 1   │              │  PlaySessionId: 2   │
     └─────────────────────┘              └─────────────────────┘
-              │                                    │
+              │                                  │
     ┌─────────▼─────────┐              ┌─────────▼─────────┐
     │ Static cache OK   │              │ Static cache OK   │
     │ Instance: 0xABC   │   ───────▶   │ Instance: 0xABC   │ (same object)
@@ -611,7 +611,7 @@ public void TearDown()
 If a singleton class has a static constructor, it may execute before `PlaySessionId` is initialized. This can rarely cause unexpected behavior.
 
 ### Thread Safety
-All singleton operations must be called from the main thread. Access from background threads throws `UnityException` (because `Application.isPlaying` is a main-thread-only API).
+All singleton operations must be called from the main thread. Access from background threads returns `null` / `false` instead of throwing exceptions, ensuring stable behavior across Unity versions.
 
 ### Scene Loading Order
 If multiple scenes contain the same singleton type, the destruction order depends on Unity's scene loading sequence.

--- a/Singletons/Core/SingletonBehaviour.cs
+++ b/Singletons/Core/SingletonBehaviour.cs
@@ -40,14 +40,14 @@ namespace Singletons.Core
         {
             get
             {
-                if (!Application.isPlaying)
-                {
-                    return AsExactType(candidate: FindAnyObjectByType<T>(findObjectsInactive: FindInactivePolicy), callerContext: "Instance[EditMode]");
-                }
-
                 if (!SingletonRuntime.ValidateMainThread(callerContext: $"{typeof(T).Name}.Instance"))
                 {
                     return null;
+                }
+
+                if (!Application.isPlaying)
+                {
+                    return AsExactType(candidate: FindAnyObjectByType<T>(findObjectsInactive: FindInactivePolicy), callerContext: "Instance[EditMode]");
                 }
 
                 InvalidateInstanceCacheIfPlaySessionChanged();
@@ -95,17 +95,17 @@ namespace Singletons.Core
         /// <returns><c>true</c> if instance exists and is valid; otherwise <c>false</c>.</returns>
         public static bool TryGetInstance(out T instance)
         {
+            if (!SingletonRuntime.ValidateMainThread(callerContext: $"{typeof(T).Name}.TryGetInstance"))
+            {
+                instance = null;
+                return false;
+            }
+
             if (!Application.isPlaying)
             {
                 instance = FindAnyObjectByType<T>(findObjectsInactive: FindInactivePolicy);
                 instance = AsExactType(candidate: instance, callerContext: "TryGetInstance[EditMode]");
                 return instance != null;
-            }
-
-            if (!SingletonRuntime.ValidateMainThread(callerContext: $"{typeof(T).Name}.TryGetInstance"))
-            {
-                instance = null;
-                return false;
             }
 
             InvalidateInstanceCacheIfPlaySessionChanged();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unity-policy-singleton",
-    "version": "3.0.6",
+    "version": "3.1.0",
     "displayName": "Policy-Driven Singleton",
     "description": "A policy-driven singleton base class for MonoBehaviour with Domain Reload support.",
     "unity": "2022.3",


### PR DESCRIPTION
## Summary

This PR fixes thread safety issues where accessing singleton `Instance` or [TryGetInstance](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonBehaviour.cs:92:8-149:9) from a background thread could throw `UnityException` due to Unity API calls (`Application.isPlaying`) being made before thread validation.

## Changes

### Core Changes

- **SingletonBehaviour.cs**: Reordered validation logic to call [ValidateMainThread](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:49:8-92:9) before `Application.isPlaying` in both `Instance` and [TryGetInstance](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonBehaviour.cs:92:8-149:9) properties
- **SingletonRuntime.cs**: Added `try-catch` block in [ValidateMainThread](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Core/SingletonRuntime.cs:49:8-92:9) to gracefully handle `UnityException` when the main thread ID is not yet captured

### Test Changes

- **SingletonTests.cs**: Updated thread safety tests to use `LogAssert.Expect` for expected error logs:
  - [BackgroundThread_Instance_ReturnsNull](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/Runtime/SingletonTests.cs:426:8-457:9)
  - [BackgroundThread_TryGetInstance_ReturnsFalse](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/Runtime/SingletonTests.cs:459:8-490:9)
  - [ThreadSafety_ValidationLayer_PreventsBackgroundAccess](cci:1://file:///C:/workspace/policy-driven-unity-singleton/Assets/unity-policy-singleton/Singletons/Tests/Runtime/SingletonTests.cs:563:8-595:9)

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Background thread access (main thread ID captured) | `UnityException` thrown | Returns `null`/`false`, logs error |
| Background thread access (main thread ID not captured) | `UnityException` thrown | Returns `null`/`false` (exception caught internally) |

## Testing

- All 53 runtime tests pass
- Thread safety tests now verify `null`/`false` returns instead of exceptions